### PR TITLE
Cleaned up Price\Value

### DIFF
--- a/Tests/eZ/Publish/Core/FieldType/Price/PriceTest.php
+++ b/Tests/eZ/Publish/Core/FieldType/Price/PriceTest.php
@@ -6,7 +6,7 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 
-namespace EzSystems\EzPriceBundle\eZ\Publish\Core\FieldType\Tests;
+namespace EzSystems\EzPriceBundle\Tests\eZ\Publish\Core\FieldType\Price\PriceTest;
 
 use eZ\Publish\Core\FieldType\Tests\FieldTypeTest;
 use EzSystems\EzPriceBundle\eZ\Publish\Core\FieldType\Price\Type as PriceType;
@@ -15,20 +15,11 @@ use EzSystems\EzPriceBundle\eZ\Publish\Core\FieldType\Price\Value as PriceValue;
 /**
  * @group fieldType
  * @group ezprice
+ * @covers \EzSystems\EzPriceBundle\eZ\Publish\Core\FieldType\Price\Type
+ * @covers \EzSystems\EzPriceBundle\eZ\Publish\Core\FieldType\Price\Value
  */
 class PriceTest extends FieldTypeTest
 {
-    /**
-     * Returns the field type under test.
-     *
-     * This method is used by all test cases to retrieve the field type under
-     * test. Just create the FieldType instance using mocks from the provided
-     * get*Mock() methods and/or custom get*Mock() implementations. You MUST
-     * NOT take care for test case wide caching of the field type, just return
-     * a new instance from this method!
-     *
-     * @return FieldType
-     */
     protected function createFieldTypeUnderTest()
     {
         $fieldType = new PriceType();
@@ -37,59 +28,21 @@ class PriceTest extends FieldTypeTest
         return $fieldType;
     }
 
-    /**
-     * Returns the validator configuration schema expected from the field type.
-     *
-     * @return array
-     */
     protected function getValidatorConfigurationSchemaExpectation()
     {
         return array();
     }
 
-    /**
-     * Returns the settings schema expected from the field type.
-     *
-     * @return array
-     */
     protected function getSettingsSchemaExpectation()
     {
         return array();
     }
 
-    /**
-     * Returns the empty value expected from the field type.
-     *
-     * @return PriceValue
-     */
     protected function getEmptyValueExpectation()
     {
         return new PriceValue;
     }
 
-    /**
-     * Data provider for invalid input to acceptValue().
-     *
-     * Returns an array of data provider sets with 2 arguments: 1. The invalid
-     * input to acceptValue(), 2. The expected exception type as a string. For
-     * example:
-     *
-     * <code>
-     *  return array(
-     *      array(
-     *          new \stdClass(),
-     *          'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
-     *      ),
-     *      array(
-     *          array(),
-     *          'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
-     *      ),
-     *      // ...
-     *  );
-     * </code>
-     *
-     * @return array
-     */
     public function provideInvalidInputForAcceptValue()
     {
         return array(
@@ -109,35 +62,6 @@ class PriceTest extends FieldTypeTest
     }
 
 
-    /**
-     * Data provider for valid input to acceptValue().
-     *
-     * Returns an array of data provider sets with 2 arguments: 1. The valid
-     * input to acceptValue(), 2. The expected return value from acceptValue().
-     * For example:
-     *
-     * <code>
-     *  return array(
-     *      array(
-     *          null,
-     *          null
-     *      ),
-     *      array(
-     *          __FILE__,
-     *          new BinaryFileValue( array(
-     *              'path' => __FILE__,
-     *              'fileName' => basename( __FILE__ ),
-     *              'fileSize' => filesize( __FILE__ ),
-     *              'downloadCount' => 0,
-     *              'mimeType' => 'text/plain',
-     *          ) )
-     *      ),
-     *      // ...
-     *  );
-     * </code>
-     *
-     * @return array
-     */
     public function provideValidInputForAcceptValue()
     {
         return array(
@@ -160,41 +84,6 @@ class PriceTest extends FieldTypeTest
         );
     }
 
-    /**
-     * Provide input for the toHash() method
-     *
-     * Returns an array of data provider sets with 2 arguments: 1. The valid
-     * input to toHash(), 2. The expected return value from toHash().
-     * For example:
-     *
-     * <code>
-     *  return array(
-     *      array(
-     *          null,
-     *          null
-     *      ),
-     *      array(
-     *          new BinaryFileValue( array(
-     *              'path' => 'some/file/here',
-     *              'fileName' => 'sindelfingen.jpg',
-     *              'fileSize' => 2342,
-     *              'downloadCount' => 0,
-     *              'mimeType' => 'image/jpeg',
-     *          ) ),
-     *          array(
-     *              'path' => 'some/file/here',
-     *              'fileName' => 'sindelfingen.jpg',
-     *              'fileSize' => 2342,
-     *              'downloadCount' => 0,
-     *              'mimeType' => 'image/jpeg',
-     *          )
-     *      ),
-     *      // ...
-     *  );
-     * </code>
-     *
-     * @return array
-     */
     public function provideInputForToHash()
     {
         return array(
@@ -204,46 +93,15 @@ class PriceTest extends FieldTypeTest
             ),
             array(
                 new PriceValue( 23.42 ),
-                23.42,
+                array( 'price' => 23.42, 'isVatIncluded' => true ),
+            ),
+            array(
+                new PriceValue( 23.42, false ),
+                array( 'price' => 23.42, 'isVatIncluded' => false ),
             ),
         );
     }
 
-    /**
-     * Provide input to fromHash() method
-     *
-     * Returns an array of data provider sets with 2 arguments: 1. The valid
-     * input to fromHash(), 2. The expected return value from fromHash().
-     * For example:
-     *
-     * <code>
-     *  return array(
-     *      array(
-     *          null,
-     *          null
-     *      ),
-     *      array(
-     *          array(
-     *              'path' => 'some/file/here',
-     *              'fileName' => 'sindelfingen.jpg',
-     *              'fileSize' => 2342,
-     *              'downloadCount' => 0,
-     *              'mimeType' => 'image/jpeg',
-     *          ),
-     *          new BinaryFileValue( array(
-     *              'path' => 'some/file/here',
-     *              'fileName' => 'sindelfingen.jpg',
-     *              'fileSize' => 2342,
-     *              'downloadCount' => 0,
-     *              'mimeType' => 'image/jpeg',
-     *          ) )
-     *      ),
-     *      // ...
-     *  );
-     * </code>
-     *
-     * @return array
-     */
     public function provideInputForFromHash()
     {
         return array(
@@ -252,8 +110,20 @@ class PriceTest extends FieldTypeTest
                 new PriceValue,
             ),
             array(
-                23.42,
+                array( 'price' => 23.42 ),
                 new PriceValue( 23.42 ),
+            ),
+            array(
+                array( 'price' => 23.42, 'isVatIncluded' => false ),
+                new PriceValue( 23.42, false ),
+            ),
+            array(
+                array( 'price' => 23.42, 'isVatIncluded' => true ),
+                new PriceValue( 23.42, true ),
+            ),
+            array(
+                array( 'price' => 23.42, 'isVatIncluded' => true ),
+                new PriceValue( 23.42, true ),
             ),
         );
     }
@@ -271,51 +141,6 @@ class PriceTest extends FieldTypeTest
         );
     }
 
-    /**
-     * Provides data sets with validator configuration and/or field settings and
-     * field value which are considered valid by the {@link validate()} method.
-     *
-     * ATTENTION: This is a default implementation, which must be overwritten if
-     * a FieldType supports validation!
-     *
-     * For example:
-     *
-     * <code>
-     *  return array(
-     *      array(
-     *          array(
-     *              "validatorConfiguration" => array(
-     *                  "StringLengthValidator" => array(
-     *                      "minStringLength" => 2,
-     *                      "maxStringLength" => 10,
-     *                  ),
-     *              ),
-     *          ),
-     *          new TextLineValue( "lalalala" ),
-     *      ),
-     *      array(
-     *          array(
-     *              "fieldSettings" => array(
-     *                  'isMultiple' => true
-     *              ),
-     *          ),
-     *          new CountryValue(
-     *              array(
-     *                  "BE" => array(
-     *                      "Name" => "Belgium",
-     *                      "Alpha2" => "BE",
-     *                      "Alpha3" => "BEL",
-     *                      "IDC" => 32,
-     *                  ),
-     *              ),
-     *          ),
-     *      ),
-     *      // ...
-     *  );
-     * </code>
-     *
-     * @return array
-     */
     public function provideValidDataForValidate()
     {
         return array(

--- a/Tests/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/PriceTest.php
+++ b/Tests/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/PriceTest.php
@@ -38,14 +38,19 @@ class PriceTest extends PHPUnit_Framework_TestCase
      */
     public function testToStorageValue()
     {
-        $fieldValue = new FieldValue;
-        $fieldValue->data = 3.1415;
+        $price = 3.1415;
+        $isVatIncluded = 1;
+
+        $fieldValue = new FieldValue(
+            array( 'data' => array( 'price' => $price, 'isVatIncluded' => $isVatIncluded ) )
+        );
 
         $storageFieldValue = new StorageFieldValue;
 
         $this->converter->toStorageValue( $fieldValue, $storageFieldValue );
 
-        self::assertEquals( $fieldValue->data, $storageFieldValue->dataFloat );
+        self::assertEquals( $price, $storageFieldValue->dataFloat );
+        self::assertEquals( "1,1", $storageFieldValue->dataText );
     }
 
     /**
@@ -53,13 +58,21 @@ class PriceTest extends PHPUnit_Framework_TestCase
      */
     public function testToFieldValue()
     {
-        $storageFieldValue = new StorageFieldValue;
-        $storageFieldValue->dataFloat = 3.1415;
+        $isVatIncluded = 1;
+        $price = 3.1415;
+
+        $storageFieldValue = new StorageFieldValue(
+            array(
+                'dataFloat' => $price,
+                'dataText' => "$isVatIncluded,1"
+            )
+        );
 
         $fieldValue = new FieldValue;
 
         $this->converter->toFieldValue( $storageFieldValue, $fieldValue );
 
-        self::assertEquals( $storageFieldValue->dataFloat, $fieldValue->data );
+        self::assertEquals( $price, $fieldValue->data['price'] );
+        self::assertEquals( $isVatIncluded, $fieldValue->data['isVatIncluded'] );
     }
 }

--- a/Tests/eZ/Publish/SPI/FieldType/PriceIntegrationTest.php
+++ b/Tests/eZ/Publish/SPI/FieldType/PriceIntegrationTest.php
@@ -74,7 +74,7 @@ class PriceIntegrationTest extends BaseIntegrationTest
     {
         return new Content\FieldValue(
             array(
-                'data'         => 42.42,
+                'data'         => array( 'price' => 42.42, 'isVatIncluded' => true ),
                 'externalData' => null,
                 'sortKey'      => 4242,
             )
@@ -92,7 +92,7 @@ class PriceIntegrationTest extends BaseIntegrationTest
     {
         return new Content\FieldValue(
             array(
-                'data'         => 23.23,
+                'data'         => array( 'price' => 23.23, 'isVatIncluded' => false ),
                 'externalData' => null,
                 'sortKey'      => 2323,
             )

--- a/eZ/Publish/Core/FieldType/Price/Type.php
+++ b/eZ/Publish/Core/FieldType/Price/Type.php
@@ -151,7 +151,7 @@ class Type extends FieldType
         {
             return null;
         }
-        return $value->price;
+        return (array)$value;
     }
 
     /**
@@ -175,9 +175,10 @@ class Type extends FieldType
      */
     public function fromPersistenceValue( FieldValue $fieldValue )
     {
-        if( !is_null( $fieldValue->data ) )
+        if ( isset( $fieldValue->data['price'] ) && $fieldValue->data['price'] != null )
         {
-            return new Value( array( 'price' => $fieldValue->data ) );
+            $isVatIncluded = isset( $fieldValue->data['is_vat_included'] ) ? (bool)$fieldValue->data['is_vat_included'] : true;
+            return new Value( $fieldValue->data['price'], $isVatIncluded );
         }
     }
 }

--- a/eZ/Publish/Core/FieldType/Price/Value.php
+++ b/eZ/Publish/Core/FieldType/Price/Value.php
@@ -13,18 +13,32 @@ use eZ\Publish\Core\FieldType\Value as BaseValue;
 class Value extends BaseValue
 {
     /**
+     * The price, that includes or not VAT, depending on {@link $isVatIncluded}
      * @var float
      */
     public $price;
 
     /**
-     * Construct a new Value object and initialize with $value
-     *
-     * @param float|null $value
+     * If VAT is, or not, included in $price {@link $isVatincluded}
+     * @var bool
      */
-    public function __construct( $value = null )
+    public $isVatIncluded = true;
+
+    /**
+     * @param float|array $price Either the price as a float, or an array of properties (price, isVatIncluded)
+     * @param bool $isVatIncluded
+     */
+    public function __construct( $price = null, $isVatIncluded = true )
     {
-        $this->price = $value;
+        if ( is_array( $price ) )
+        {
+            parent::__construct( $price );
+        }
+        else
+        {
+            $this->price = $price;
+            $this->isVatIncluded = $isVatIncluded;
+        }
     }
 
     public function __toString()

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/Price.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/Price.php
@@ -30,13 +30,20 @@ class Price implements Converter
 
     public function toStorageValue( FieldValue $value, StorageFieldValue $storageFieldValue )
     {
-        $storageFieldValue->dataFloat = $value->data;
+        $storageFieldValue->dataFloat = $value->data['price'];
+        $storageFieldValue->dataText = (int)$value->data['isVatIncluded'] . ',1';
         $storageFieldValue->sortKeyInt = $value->sortKey;
     }
 
     public function toFieldValue( StorageFieldValue $value, FieldValue $fieldValue )
     {
-        $fieldValue->data = $value->dataFloat;
+        $fieldValue->data = array( 'price' => $value->dataFloat );
+
+        if ( strstr( $value->dataText, ',' ) !== false )
+        {
+            list( $isVatIncluded ) = explode( ',', $value->dataText );
+            $fieldValue->data['isVatIncluded'] = (bool)$isVatIncluded;
+        }
         $fieldValue->sortKey = $value->sortKeyInt;
     }
 


### PR DESCRIPTION
Finalized Value properties.
#### Type

hash & persistence handling have been updated.
#### Converter

Now reads data_text, formatted as "<isVatIncluded>,<vatId>", and sets the appropriate value.
#### Value

Now has two properties: `(float)$price` and `(bool)$isVatIncluded`.
The Value constructor now accepts, for convenience:
- either an array of properties,
- or a price.
