### PR TITLE
Implemented Twig extension + services interfaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
 branches:
   only:
     - master
+    - dev
+    - EZP-23049-price_service
 
 # install dependencies
 install: composer install --dev --prefer-dist

--- a/API/Price/PriceValueWithVatDataCalculator.php
+++ b/API/Price/PriceValueWithVatDataCalculator.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * This file is part of the eZ Publish Legacy package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPriceBundle\API\Price;
+
+use EzSystems\EzPriceBundle\API\Price\Values\VatRate;
+use EzSystems\EzPriceBundle\eZ\Publish\Core\FieldType\Price\Value as PriceValue;
+
+/**
+ * Creates PriceWithVatData objects based on Price Value + VatRate
+ */
+interface PriceValueWithVatDataCalculator
+{
+    /**
+     * @param array $value
+     * @param VatRate $vatRate
+     *
+     * @return \EzSystems\EzPriceBundle\API\Price\Values\PriceWithVatData
+     */
+    public function getValueWithVatData( array $value, VatRate $vatRate );
+}

--- a/API/Price/Values/PriceWithVatData.php
+++ b/API/Price/Values/PriceWithVatData.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * This file is part of the EzPriceBundle package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPriceBundle\API\Price\Values;
+
+use EzSystems\EzPriceBundle\eZ\Publish\Core\FieldType\Price\Value as PriceValue;
+
+/**
+ * A Price\Value with extra information about VAT
+ */
+class PriceWithVatData extends PriceValue
+{
+    /** @var float */
+    protected $priceIncludingVat;
+
+    /** @var float */
+    protected $priceExcludingVat;
+
+    /** @var float */
+    protected $vatRate;
+}

--- a/API/Price/Values/VatRate.php
+++ b/API/Price/Values/VatRate.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * This file is part of the EzPriceBundle package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\EzPriceBundle\API\Price\Values;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * @property-read float $percentage
+ * @property-read string $name
+ */
+class VatRate extends ValueObject
+{
+    /** @var float */
+    protected $percentage;
+
+    /** @var string */
+    protected $name;
+}

--- a/API/Price/VatService.php
+++ b/API/Price/VatService.php
@@ -8,6 +8,15 @@
 
 namespace EzSystems\EzPriceBundle\API\Price;
 
+use EzSystems\EzPriceBundle\API\Price\Values\VatRate;
+
 interface VatService
 {
+    /**
+     * Loads the VAT rate for $fieldId in $versionNo
+     * @param mixed $fieldId
+     * @param int $versionNo
+     * @return \EzSystems\EzPriceBundle\API\Price\Values\VatRate
+     */
+    public function loadVatRate( $fieldId, $versionNo );
 }

--- a/Core/Price/PriceValueWithVatDataCalculator.php
+++ b/Core/Price/PriceValueWithVatDataCalculator.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * This file is part of the eZ Publish Legacy package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributd with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPriceBundle\Core\Price;
+
+use EzSystems\EzPriceBundle\API\Price\Values\PriceWithVatData;
+use EzSystems\EzPriceBundle\API\Price\Values\VatRate;
+use EzSystems\EzPriceBundle\eZ\Publish\Core\FieldType\Price\Value as PriceValue;
+use EzSystems\EzPriceBundle\API\Price\PriceValueWithVatDataCalculator as PriceValueWithVatDataCalculatorInterface;
+
+/**
+ * Creates PriceWithVatData objects based on Price Value + VatRate
+ */
+class PriceValueWithVatDataCalculator implements PriceValueWithVatDataCalculatorInterface
+{
+    public function getValueWithVatData( array $price, VatRate $vatRate )
+    {
+        $priceWithVatInfo = $price;
+
+        $vatRatio = 1 + ( $vatRate->percentage / 100 );
+        if ( $price['isVatIncluded'] )
+        {
+            $priceWithVatInfo['priceIncludingVat'] = $price['price'];
+            $priceWithVatInfo['priceExcludingVat'] = $price['price'] / $vatRatio;
+        }
+        else
+        {
+            $priceWithVatInfo['priceExcludingVat'] = $price['price'];
+            $priceWithVatInfo['priceIncludingVat'] = $price['price'] * $vatRatio;
+        }
+
+        return $priceWithVatInfo;
+    }
+}

--- a/Tests/Core/Price/PriceValueWithVatDataCalculatorTest.php
+++ b/Tests/Core/Price/PriceValueWithVatDataCalculatorTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * This file is part of the eZ Publish Legacy package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributd with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\EzPriceBundle\Tests\Core\Price;
+
+use EzSystems\EzPriceBundle\API\Price\Values\VatRate;
+use EzSystems\EzPriceBundle\Core\Price\PriceValueWithVatDataCalculator;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * @covers \EzSystems\EzPriceBundle\Core\Price\PriceValueWithVatDataCalculator
+ */
+class PriceValueWithVatDataCalculatorTest extends PHPUnit_Framework_TestCase
+{
+    /** @var \EzSystems\EzPriceBundle\Core\Price\PriceValueWithVatDataCalculator */
+    private $calculator;
+
+    public function setUp()
+    {
+        $this->calculator = new PriceValueWithVatDataCalculator();
+    }
+
+    public function testVatDataVatExcluded()
+    {
+        $price = array(
+            'price' => 120.6,
+            'isVatIncluded' => true
+        );
+
+        $vatRate = new VatRate(
+            array(
+                'percentage' => 20.6,
+                'name' => 'test'
+            )
+        );
+
+        $priceWithVat = $this->calculator->getValueWithVatData(
+            $price,
+            $vatRate
+        );
+
+        self::assertEquals( true, $priceWithVat['isVatIncluded'] );
+        self::assertEquals( 120.6, $priceWithVat['price'] );
+        self::assertEquals( 120.6, $priceWithVat['priceIncludingVat'] );
+        self::assertEquals( 100, $priceWithVat['priceExcludingVat'] );
+    }
+
+    public function testVatDataVatIncluded()
+    {
+        $price = array(
+            'price' => 100,
+            'isVatIncluded' => false
+        );
+
+        $vatRate = new VatRate(
+            array(
+                'percentage' => 20.6,
+                'name' => 'test'
+            )
+        );
+
+        $priceWithVat = $this->calculator->getValueWithVatData(
+            $price,
+            $vatRate
+        );
+
+        self::assertEquals( false, $priceWithVat['isVatIncluded'] );
+        self::assertEquals( 100, $priceWithVat['price'] );
+        self::assertEquals( 120.6, $priceWithVat['priceIncludingVat'] );
+        self::assertEquals( 100, $priceWithVat['priceExcludingVat'] );
+    }
+}

--- a/Tests/Twig/Extension/PriceExtensionTest.php
+++ b/Tests/Twig/Extension/PriceExtensionTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * This file is part of the EzPriceBundle package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\EzPriceBundle\Tests\Twig\Extension;
+
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
+use EzSystems\EzPriceBundle\API\Price\Values\PriceWithVatData;
+use EzSystems\EzPriceBundle\API\Price\Values\VatRate;
+use EzSystems\EzPriceBundle\Core\Price\PriceValueWithVatDataCalculator;
+use EzSystems\EzPriceBundle\Twig\Extension\PriceExtension;
+use Twig_Test_IntegrationTestCase;
+
+/**
+ * @covers \EzSystems\EzPriceBundle\Twig\Extension\PriceExtension
+ */
+class PriceExtensionTest extends Twig_Test_IntegrationTestCase
+{
+    /**
+     * @return array
+     */
+    protected function getExtensions()
+    {
+        return [
+            new PriceExtension(
+                $this->getVatServiceMock(),
+                new PriceValueWithVatDataCalculator()
+            )
+        ];
+    }
+
+    private function getVatServiceMock()
+    {
+        $vatRate = new VatRate( array( 'percentage' => 10.0, 'name' => 'test' ) );
+
+        $mock = $this->getMock( 'EzSystems\EzPriceBundle\API\Price\VatService' );
+        $mock->expects( $this->any() )
+            ->method( 'loadVatRate' )
+            ->will( $this->returnValue( $vatRate ) );
+
+        return $mock;
+    }
+
+    /**
+     * @param float $price
+     * @param bool $isVatIncluded
+     *
+     * @return Field
+     */
+    protected function createField( $price, $isVatIncluded )
+    {
+        return new Field(
+            array(
+                'value' => array(
+                    'price' => $price,
+                    'isVatIncluded' => $isVatIncluded
+                )
+            )
+        );
+    }
+
+    protected function createVersionInfo()
+    {
+        return new VersionInfo( array( 'versionNo' => 1 ) );
+    }
+
+    /**
+     * @return string
+     */
+    protected function getFixturesDir()
+    {
+        return __DIR__ . '/_fixtures/ezprice_value';
+    }
+}

--- a/Tests/Twig/Extension/_fixtures/ezprice_value/ezprice_value.test
+++ b/Tests/Twig/Extension/_fixtures/ezprice_value/ezprice_value.test
@@ -1,0 +1,54 @@
+--TEST--
+"ezprice_value" function
+--TEMPLATE--
+{% set price = ezprice_value( versionInfo, field ) %}
+Price including VAT: {{ price.priceIncludingVat }}
+Price excluding VAT: {{ price.priceExcludingVat }}
+--DATA--
+return array(
+    'field' => $this->createField( 3.1415, 1 ),
+    'versionInfo' => $this->createVersionInfo()
+)
+--EXPECT--
+Price including VAT: 3.1415
+Price excluding VAT: 2.8559090909091
+--DATA--
+return array(
+    'field' => $this->createField( 3.1415, 0 ),
+    'versionInfo' => $this->createVersionInfo()
+)
+--EXPECT--
+Price including VAT: 3.45565
+Price excluding VAT: 3.1415
+--DATA--
+return array(
+    'field' => $this->createField( 10, 0 ),
+    'versionInfo' => $this->createVersionInfo()
+)
+--EXPECT--
+Price including VAT: 11
+Price excluding VAT: 10
+--DATA--
+return array(
+    'field' => $this->createField( 11, 1 ),
+    'versionInfo' => $this->createVersionInfo()
+)
+--EXPECT--
+Price including VAT: 11
+Price excluding VAT: 10
+--DATA--
+return array(
+    'field' => $this->createField( 100, 0 ),
+    'versionInfo' => $this->createVersionInfo()
+)
+--EXPECT--
+Price including VAT: 110
+Price excluding VAT: 100
+--DATA--
+return array(
+    'field' => $this->createField( 100, 1 ),
+    'versionInfo' => $this->createVersionInfo()
+)
+--EXPECT--
+Price including VAT: 100
+Price excluding VAT: 90.909090909091

--- a/Twig/Extension/PriceExtension.php
+++ b/Twig/Extension/PriceExtension.php
@@ -9,11 +9,25 @@
 namespace EzSystems\EzPriceBundle\Twig\Extension;
 
 use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
+use EzSystems\EzPriceBundle\API\Price\PriceValueWithVatDataCalculator;
+use EzSystems\EzPriceBundle\API\Price\VatService;
 use Twig_Extension;
 use Twig_SimpleFunction;
 
 class PriceExtension extends Twig_Extension
 {
+    /** @var \EzSystems\EzPriceBundle\API\Price\VatService */
+    private $vatService;
+
+    /** @var \EzSystems\EzPriceBundle\API\Price\PriceValueWithVatDataCalculator */
+    private $calculator;
+
+    public function __construct( VatService $vatService, PriceValueWithVatDataCalculator $calculator )
+    {
+        $this->vatService = $vatService;
+        $this->calculator = $calculator;
+    }
     /**
      * Returns the name of the extension.
      *
@@ -47,7 +61,12 @@ class PriceExtension extends Twig_Extension
      *
      * @return string
      */
-    public function priceValue( Field $price )
+    public function priceValue( VersionInfo $versionInfo, Field $price )
     {
+        return $this->calculator->getValueWithVatData(
+            $price->value,
+            $this->vatService->loadVatRate( $price->id, $versionInfo->versionNo )
+        );
+
     }
 }


### PR DESCRIPTION
## Changes

Adds `includeVat()`, `excludeVat()` and `loadVatRate()` to `VatService` interface.

Implements the `ezprice_value` twig extension. Given a price fieldId + versionInfo, it applies the rate depending on `isVatInclude`, and returns an enriched `Price\Value` that contains `price_included_vat` and `price_excluding_vat` properties.
## Testing

The twig extension is covered with a twig integration test that covers prices with and without vat included.
